### PR TITLE
Update class.importmodel.php

### DIFF
--- a/applications/dashboard/models/class.importmodel.php
+++ b/applications/dashboard/models/class.importmodel.php
@@ -2228,7 +2228,7 @@ class ImportModel extends Gdn_Model {
                 $inserts .= ',';
             }
             $inserts .= '('.implode(',', $row).')';
-            $inserts = str_replace("'NULL',", "null", $inserts);  // Need to replace any 'NULL',  values with actual null value for database
+            $inserts = str_replace("'NULL',", "null,", $inserts);  // Need to replace any 'NULL',  values with actual null value for database
 
             if ($count >= $chunk) {
                 // Insert in chunks.


### PR DESCRIPTION
This change will allows \Ns from import files using the porter to be inserted as NULLS and not ''

This fixes issue
https://github.com/vanilla/vanilla/issues/10302

This turns \N from an import file to a string value of 'NULL' then after the trim and implode command is run you replace the 'NULL', on the SQL query to be null, so that SQL sees them as a proper null values